### PR TITLE
Encapsulate shedding threshold logic

### DIFF
--- a/gci/src/main/java/com/gcinterceptor/gci/SheddingThreshold.java
+++ b/gci/src/main/java/com/gcinterceptor/gci/SheddingThreshold.java
@@ -1,0 +1,53 @@
+package com.gcinterceptor.gci;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class SheddingThreshold {
+	private final long MIN_SHEDDING_THRESHOLD = 32 * 1024 * 1024; // TODO(David) Update this value, if needed
+	private final long MAX_SHEDDING_THRESHOLD = 512 * 1024 * 1024;  // TODO(David) Update this value, if needed 
+	private final double START_MAX_OVER_HEAD = (float) 0.1; // Maximum accepted Overhead (#shed/#processed)
+	private final long SMOOTH_FACTOR = 5;   // Smooth out the exponential decay.
+	// Looking at the function we can see where that at 22 it reaches the overhead of 0.001.
+	// https://www.wolframcloud.com/objects/danielfireman/gci_overhead_exp_decay
+	private final int MAX_GCS =  23; // TODO(David) Update this value, if needed
+	
+	private AtomicLong threshold;
+	private int numGCs;
+	
+	public SheddingThreshold() {
+		threshold = new AtomicLong((long) (MIN_SHEDDING_THRESHOLD + (Math.random() * MIN_SHEDDING_THRESHOLD)));
+	}
+	
+	public double getThreshold() {
+		return threshold.get();
+	}
+	
+	public void updateThreshold(int alloc, int finished, int shedRequests) {
+		// Calculating the maximum overhead via exponential decay
+		// https://en.wikipedia.org/wiki/Exponential_decay
+		// https://www.wolframcloud.com/objects/danielfireman/gci_overhead_exp_decay
+		double maxOverhead = (START_MAX_OVER_HEAD / Math.exp(SMOOTH_FACTOR* numGCs));
+		// That way we avoid h.numGCs unbound growth.
+		numGCs = Math.min(MAX_GCS, numGCs + 1);
+		
+		// Updating threshold value.
+		long thresholdCandidate = 0;
+		double overhead = (double) shedRequests / ((double) finished); 
+		if ( overhead  > maxOverhead) {
+			thresholdCandidate = (long) (alloc - (Math.random() * MIN_SHEDDING_THRESHOLD));
+		} else {
+			thresholdCandidate = (long) (alloc + (Math.random() * MIN_SHEDDING_THRESHOLD));
+		}
+		
+		// Checking ST bounds.
+		if (thresholdCandidate <= MIN_SHEDDING_THRESHOLD) {
+			thresholdCandidate = (long) (MIN_SHEDDING_THRESHOLD + (Math.random() * MIN_SHEDDING_THRESHOLD));			
+		}
+		else if (thresholdCandidate >= MAX_SHEDDING_THRESHOLD) {
+			thresholdCandidate = (long) (MAX_SHEDDING_THRESHOLD - (Math.random() * MIN_SHEDDING_THRESHOLD));			
+		}
+		
+		threshold.set(thresholdCandidate); 
+	}
+
+}

--- a/gci/src/main/java/com/gcinterceptor/gci/SheddingThreshold.java
+++ b/gci/src/main/java/com/gcinterceptor/gci/SheddingThreshold.java
@@ -2,7 +2,10 @@ package com.gcinterceptor.gci;
 
 import java.util.concurrent.atomic.AtomicLong;
 
-public class SheddingThreshold {
+class SheddingThreshold {
+	/**
+	 * Default heap threshold rate should be fairly small, so the first collection happens quickly.
+	 */
 	private final long MIN_SHEDDING_THRESHOLD = 32 * 1024 * 1024; // TODO(David) Update this value, if needed
 	private final long MAX_SHEDDING_THRESHOLD = 512 * 1024 * 1024;  // TODO(David) Update this value, if needed
 	
@@ -21,15 +24,15 @@ public class SheddingThreshold {
 	private AtomicLong threshold;
 	private int numGCs;
 	
-	public SheddingThreshold() {
+	SheddingThreshold() {
 		threshold = new AtomicLong((long) (MIN_SHEDDING_THRESHOLD + (Math.random() * MIN_SHEDDING_THRESHOLD)));
 	}
 	
-	public double get() {
+	double get() {
 		return threshold.get();
 	}
 	
-	public void update(int alloc, int finished, int shedRequests) {
+	void update(int alloc, int finished, int shedRequests) {
 		// Calculating the maximum overhead via exponential decay
 		// https://en.wikipedia.org/wiki/Exponential_decay
 		// https://www.wolframcloud.com/objects/danielfireman/gci_overhead_exp_decay

--- a/gci/src/main/java/com/gcinterceptor/gci/SheddingThreshold.java
+++ b/gci/src/main/java/com/gcinterceptor/gci/SheddingThreshold.java
@@ -11,7 +11,7 @@ class SheddingThreshold {
 
 	/**
 	 * The maximum value of shedding threshold to collect. Default heap threshold rate should
-	 * be fairly bigger, aiming at to avoid overflow of memory.
+	 * be not too bigger, aiming at to avoid overflow of memory.
 	 */
 	private final long MAX_SHEDDING_THRESHOLD = 512 * 1024 * 1024; // TODO(David) Update this value, if needed
 

--- a/gci/src/main/java/com/gcinterceptor/gci/SheddingThreshold.java
+++ b/gci/src/main/java/com/gcinterceptor/gci/SheddingThreshold.java
@@ -4,34 +4,42 @@ import java.util.concurrent.atomic.AtomicLong;
 
 class SheddingThreshold {
 	/**
-	 * Default heap threshold rate should be fairly small, so the first collection happens quickly.
+	 * The minimum value of shedding threshold to collect. Default heap threshold rate should
+	 * be fairly small, so the first collection happens quickly.
 	 */
 	private final long MIN_SHEDDING_THRESHOLD = 32 * 1024 * 1024; // TODO(David) Update this value, if needed
-	private final long MAX_SHEDDING_THRESHOLD = 512 * 1024 * 1024;  // TODO(David) Update this value, if needed
-	
-	/** Maximum accepted Overhead (#shed/#processed). */
-	private final double START_MAX_OVERHEAD = (float) 0.1; 
-	
-	/** Smooth out the exponential decay. */
-	private final long SMOOTH_FACTOR = 5;   
-	
-	/** 
-	 *  Looking at the function we can see where that at 22 it reaches the overhead of 0.001. 
-	 *  https://www.wolframcloud.com/objects/danielfireman/gci_overhead_exp_decay.
+
+	/**
+	 * The maximum value of shedding threshold to collect. Default heap threshold rate should
+	 * be fairly bigger, aiming at to avoid overflow of memory.
 	 */
-	private final int MAX_GCS =  23; // TODO(David) Update this value, if needed
-	
+	private final long MAX_SHEDDING_THRESHOLD = 512 * 1024 * 1024; // TODO(David) Update this value, if needed
+
+	/** Maximum accepted Overhead (#shed/#processed). */
+	private final double START_MAX_OVERHEAD = (float) 0.1;
+
+	/** Smooth out the exponential decay. */
+	private final long SMOOTH_FACTOR = 5;
+
+	/**
+	 * Is the max number of collects that can be used to calculate the max overhead.
+	 * Looking at the function we can see where that at 22 it reaches the overhead
+	 * of 0.001.
+	 * https://www.wolframcloud.com/objects/danielfireman/gci_overhead_exp_decay.
+	 */
+	private final int MAX_GCS = 23; // TODO(David) Update this value, if needed
+
 	private AtomicLong threshold;
 	private int numGCs;
-	
+
 	SheddingThreshold() {
 		threshold = new AtomicLong((long) (MIN_SHEDDING_THRESHOLD + (Math.random() * MIN_SHEDDING_THRESHOLD)));
 	}
-	
+
 	double get() {
 		return threshold.get();
 	}
-	
+
 	void update(int alloc, int finished, int shedRequests) {
 		// Calculating the maximum overhead via exponential decay
 		// https://en.wikipedia.org/wiki/Exponential_decay
@@ -39,25 +47,24 @@ class SheddingThreshold {
 		double maxOverhead = (START_MAX_OVERHEAD / Math.exp(SMOOTH_FACTOR * numGCs));
 		// That way we avoid h.numGCs unbound growth.
 		numGCs = Math.min(MAX_GCS, numGCs + 1);
-		
+
 		// Updating threshold value.
 		long thresholdCandidate = 0;
-		double overhead = (double) shedRequests / (double) finished; 
+		double overhead = (double) shedRequests / (double) finished;
 		if (overhead > maxOverhead) {
 			thresholdCandidate = (long) (alloc - (Math.random() * MIN_SHEDDING_THRESHOLD));
 		} else {
 			thresholdCandidate = (long) (alloc + (Math.random() * MIN_SHEDDING_THRESHOLD));
 		}
-		
+
 		// Checking ST bounds.
 		if (thresholdCandidate <= MIN_SHEDDING_THRESHOLD) {
-			thresholdCandidate = (long) (MIN_SHEDDING_THRESHOLD + (Math.random() * MIN_SHEDDING_THRESHOLD));			
+			thresholdCandidate = (long) (MIN_SHEDDING_THRESHOLD + (Math.random() * MIN_SHEDDING_THRESHOLD));
+		} else if (thresholdCandidate >= MAX_SHEDDING_THRESHOLD) {
+			thresholdCandidate = (long) (MAX_SHEDDING_THRESHOLD - (Math.random() * MIN_SHEDDING_THRESHOLD));
 		}
-		else if (thresholdCandidate >= MAX_SHEDDING_THRESHOLD) {
-			thresholdCandidate = (long) (MAX_SHEDDING_THRESHOLD - (Math.random() * MIN_SHEDDING_THRESHOLD));			
-		}
-		
-		threshold.set(thresholdCandidate); 
+
+		threshold.set(thresholdCandidate);
 	}
 
 }

--- a/gci/src/main/java/com/gcinterceptor/gci/SheddingThreshold.java
+++ b/gci/src/main/java/com/gcinterceptor/gci/SheddingThreshold.java
@@ -5,7 +5,7 @@ import java.util.concurrent.atomic.AtomicLong;
 public class SheddingThreshold {
 	private final long MIN_SHEDDING_THRESHOLD = 32 * 1024 * 1024; // TODO(David) Update this value, if needed
 	private final long MAX_SHEDDING_THRESHOLD = 512 * 1024 * 1024;  // TODO(David) Update this value, if needed 
-	private final double START_MAX_OVER_HEAD = (float) 0.1; // Maximum accepted Overhead (#shed/#processed)
+	private final double START_MAX_OVERHEAD = (float) 0.1; // Maximum accepted Overhead (#shed/#processed)
 	private final long SMOOTH_FACTOR = 5;   // Smooth out the exponential decay.
 	// Looking at the function we can see where that at 22 it reaches the overhead of 0.001.
 	// https://www.wolframcloud.com/objects/danielfireman/gci_overhead_exp_decay
@@ -18,22 +18,22 @@ public class SheddingThreshold {
 		threshold = new AtomicLong((long) (MIN_SHEDDING_THRESHOLD + (Math.random() * MIN_SHEDDING_THRESHOLD)));
 	}
 	
-	public double getThreshold() {
+	public double get() {
 		return threshold.get();
 	}
 	
-	public void updateThreshold(int alloc, int finished, int shedRequests) {
+	public void update(int alloc, int finished, int shedRequests) {
 		// Calculating the maximum overhead via exponential decay
 		// https://en.wikipedia.org/wiki/Exponential_decay
 		// https://www.wolframcloud.com/objects/danielfireman/gci_overhead_exp_decay
-		double maxOverhead = (START_MAX_OVER_HEAD / Math.exp(SMOOTH_FACTOR* numGCs));
+		double maxOverhead = (START_MAX_OVERHEAD / Math.exp(SMOOTH_FACTOR* numGCs));
 		// That way we avoid h.numGCs unbound growth.
 		numGCs = Math.min(MAX_GCS, numGCs + 1);
 		
 		// Updating threshold value.
 		long thresholdCandidate = 0;
-		double overhead = (double) shedRequests / ((double) finished); 
-		if ( overhead  > maxOverhead) {
+		double overhead = (double) shedRequests / (double) finished; 
+		if (overhead > maxOverhead) {
 			thresholdCandidate = (long) (alloc - (Math.random() * MIN_SHEDDING_THRESHOLD));
 		} else {
 			thresholdCandidate = (long) (alloc + (Math.random() * MIN_SHEDDING_THRESHOLD));

--- a/gci/src/main/java/com/gcinterceptor/gci/SheddingThreshold.java
+++ b/gci/src/main/java/com/gcinterceptor/gci/SheddingThreshold.java
@@ -4,11 +4,18 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class SheddingThreshold {
 	private final long MIN_SHEDDING_THRESHOLD = 32 * 1024 * 1024; // TODO(David) Update this value, if needed
-	private final long MAX_SHEDDING_THRESHOLD = 512 * 1024 * 1024;  // TODO(David) Update this value, if needed 
-	private final double START_MAX_OVERHEAD = (float) 0.1; // Maximum accepted Overhead (#shed/#processed)
-	private final long SMOOTH_FACTOR = 5;   // Smooth out the exponential decay.
-	// Looking at the function we can see where that at 22 it reaches the overhead of 0.001.
-	// https://www.wolframcloud.com/objects/danielfireman/gci_overhead_exp_decay
+	private final long MAX_SHEDDING_THRESHOLD = 512 * 1024 * 1024;  // TODO(David) Update this value, if needed
+	
+	/** Maximum accepted Overhead (#shed/#processed). */
+	private final double START_MAX_OVERHEAD = (float) 0.1; 
+	
+	/** Smooth out the exponential decay. */
+	private final long SMOOTH_FACTOR = 5;   
+	
+	/** 
+	 *  Looking at the function we can see where that at 22 it reaches the overhead of 0.001. 
+	 *  https://www.wolframcloud.com/objects/danielfireman/gci_overhead_exp_decay.
+	 */
 	private final int MAX_GCS =  23; // TODO(David) Update this value, if needed
 	
 	private AtomicLong threshold;
@@ -26,7 +33,7 @@ public class SheddingThreshold {
 		// Calculating the maximum overhead via exponential decay
 		// https://en.wikipedia.org/wiki/Exponential_decay
 		// https://www.wolframcloud.com/objects/danielfireman/gci_overhead_exp_decay
-		double maxOverhead = (START_MAX_OVERHEAD / Math.exp(SMOOTH_FACTOR* numGCs));
+		double maxOverhead = (START_MAX_OVERHEAD / Math.exp(SMOOTH_FACTOR * numGCs));
 		// That way we avoid h.numGCs unbound growth.
 		numGCs = Math.min(MAX_GCS, numGCs + 1);
 		


### PR DESCRIPTION
This PR ports shedding threshold logic from [gci-go shedding threshold](https://github.com/gcinterceptor/gci-go/blob/master/gccontrol/shedding_threshold.go) to gci-java.