### PR TITLE
Tests for Heap and Threshold classes.

### DIFF
--- a/core/src/main/java/com/gcinterceptor/core/SheddingThreshold.java
+++ b/core/src/main/java/com/gcinterceptor/core/SheddingThreshold.java
@@ -36,7 +36,7 @@ class SheddingThreshold {
 		threshold = new AtomicLong((long) (MIN_SHEDDING_THRESHOLD + (Math.random() * MIN_SHEDDING_THRESHOLD)));
 	}
 
-	int numbGCs() {
+	int numGCs() {
 		return numGCs;
 	}
 	

--- a/core/src/main/java/com/gcinterceptor/core/SheddingThreshold.java
+++ b/core/src/main/java/com/gcinterceptor/core/SheddingThreshold.java
@@ -36,6 +36,10 @@ class SheddingThreshold {
 		threshold = new AtomicLong((long) (MIN_SHEDDING_THRESHOLD + (Math.random() * MIN_SHEDDING_THRESHOLD)));
 	}
 
+	int numbGCs() {
+		return numGCs;
+	}
+	
 	double get() {
 		return threshold.get();
 	}

--- a/core/src/test/java/com/gcinterceptor/core/HeapTest.java
+++ b/core/src/test/java/com/gcinterceptor/core/HeapTest.java
@@ -1,0 +1,31 @@
+package com.gcinterceptor.core;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class HeapTest {
+
+	@Test
+	public void testHeap() {
+		Heap heap = new Heap();
+		assertEquals(0, heap.getHeapUsageSinceLastGC());
+		int n = 5;
+		long arrayCost = 4000016; // 4 bytes * 10^6 + 16 bytes (array default cost) = 4,000016MB.
+		for (int i = 1; i <= n; i++) {
+			int[] array = new int[1000000];
+			assertEquals(i * arrayCost, heap.getHeapUsageSinceLastGC());
+		}
+		assertEquals(n * arrayCost, heap.collect());
+
+		long alloc = heap.getHeapUsageSinceLastGC();
+		assertTrue(alloc < n * arrayCost); // Ensure the heap was cleaned.
+		for (int i = 1; i <= n; i++) {
+			int[] array = new int[1000000];
+			assertEquals(i * arrayCost + alloc, heap.getHeapUsageSinceLastGC());
+		}
+		assertEquals(n * arrayCost + alloc, heap.collect());
+		
+	}
+
+}

--- a/core/src/test/java/com/gcinterceptor/core/HeapTest.java
+++ b/core/src/test/java/com/gcinterceptor/core/HeapTest.java
@@ -25,7 +25,5 @@ public class HeapTest {
 			assertEquals(i * arrayCost + alloc, heap.getHeapUsageSinceLastGC());
 		}
 		assertEquals(n * arrayCost + alloc, heap.collect());
-		
 	}
-
 }

--- a/core/src/test/java/com/gcinterceptor/core/SamplerTest.java
+++ b/core/src/test/java/com/gcinterceptor/core/SamplerTest.java
@@ -1,0 +1,61 @@
+package com.gcinterceptor.core;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class SamplerTest {
+	private final int DEFAULT_SAMPLE_RATE = 64;
+	private final int MAX_SAMPLE_RATE = 512;
+	private Sampler sampler;
+	
+	@Before
+	public void setUp() {
+		sampler = new Sampler(5);
+	}
+	 
+	@Test
+	public void testSampler() {	
+		assertEquals(DEFAULT_SAMPLE_RATE, sampler.getCurrentSampleSize());
+		for (int i = 0; i < 5; i++) {
+			sampler.update(80);			
+			assertEquals(80, sampler.getCurrentSampleSize());
+		}
+		
+		for (int i = 0; i < 4; i++) {
+			sampler.update(MAX_SAMPLE_RATE);			
+			assertEquals(80, sampler.getCurrentSampleSize());
+		}
+		sampler.update(MAX_SAMPLE_RATE);			
+		assertEquals(MAX_SAMPLE_RATE, sampler.getCurrentSampleSize());
+		
+		for (int i = 0; i < 5; i++) {
+			sampler.update(DEFAULT_SAMPLE_RATE);
+			assertEquals(DEFAULT_SAMPLE_RATE, sampler.getCurrentSampleSize());
+		}
+	}
+	
+	@Test
+	public void testBounds() {
+		sampler.update(-1);			
+		assertEquals(64, sampler.getCurrentSampleSize());
+		for (int i = 0; i < 4; i++) {
+			sampler.update(MAX_SAMPLE_RATE);
+			assertEquals(64, sampler.getCurrentSampleSize());
+		}
+		sampler.update(MAX_SAMPLE_RATE);
+		assertEquals(MAX_SAMPLE_RATE, sampler.getCurrentSampleSize());
+		
+		sampler.update(-1);			
+		assertEquals(MAX_SAMPLE_RATE, sampler.getCurrentSampleSize());
+		for (int i = 0; i < 4; i++) {
+			sampler.update(2 * MAX_SAMPLE_RATE);
+			assertEquals(MAX_SAMPLE_RATE, sampler.getCurrentSampleSize());
+		}
+		sampler.update(2 * MAX_SAMPLE_RATE);
+		assertEquals(MAX_SAMPLE_RATE, sampler.getCurrentSampleSize());
+
+	}
+
+}

--- a/core/src/test/java/com/gcinterceptor/core/SheddingThresholdTest.java
+++ b/core/src/test/java/com/gcinterceptor/core/SheddingThresholdTest.java
@@ -18,7 +18,7 @@ public class SheddingThresholdTest {
 	
 	@Test
 	public void testSheddingThreshold() { 
-		assertEquals(0, st.numbGCs());
+		assertEquals(0, st.numGCs());
 		assertTrue(st.get() >= MIN_SHEDDING_THRESHOLD && st.get() <= 2 * MIN_SHEDDING_THRESHOLD);
 	}
 
@@ -32,7 +32,7 @@ public class SheddingThresholdTest {
 		}
 		st.update(alloc, 1000, 50);
 		assertTrue(st.get() < alloc);
-		assertEquals(st.numbGCs(), MAX_GCS);
+		assertEquals(st.numGCs(), MAX_GCS);
 	}
 	
 	@Test
@@ -42,7 +42,5 @@ public class SheddingThresholdTest {
 
 		st.update(2 * MAX_SHEDDING_THRESHOLD, 1000, 1000);
 		assertTrue(st.get() <= MAX_SHEDDING_THRESHOLD);
-		
 	}
-
 }

--- a/core/src/test/java/com/gcinterceptor/core/SheddingThresholdTest.java
+++ b/core/src/test/java/com/gcinterceptor/core/SheddingThresholdTest.java
@@ -1,0 +1,48 @@
+package com.gcinterceptor.core;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class SheddingThresholdTest {
+	private final long MIN_SHEDDING_THRESHOLD = 32 * 1024 * 1024; 
+	private final long MAX_SHEDDING_THRESHOLD = 512 * 1024 * 1024;
+	private final int MAX_GCS = 23;
+	private SheddingThreshold st;
+	
+	@Before
+	public void setUp() {
+		st = new SheddingThreshold();
+	}
+	
+	@Test
+	public void testSheddingThreshold() { 
+		assertEquals(0, st.numbGCs());
+		assertTrue(st.get() >= MIN_SHEDDING_THRESHOLD && st.get() <= 2 * MIN_SHEDDING_THRESHOLD);
+	}
+
+	@Test
+	public void testUpdate() {
+		long alloc = 256 * 1025 * 1024;
+		st.update(alloc, 1000, 50); // It is fine for the first run (see startMaxOverhead).
+		assertTrue(st.get() > alloc);
+		for (int i = 0; i < MAX_GCS; i++) {
+			st.update(alloc, 1000, 50);	
+		}
+		st.update(alloc, 1000, 50);
+		assertTrue(st.get() < alloc);
+		assertEquals(st.numbGCs(), MAX_GCS);
+	}
+	
+	@Test
+	public void testBounds() {
+		st.update(MIN_SHEDDING_THRESHOLD / 2, 1000, 1000);
+		assertTrue(st.get() >= MIN_SHEDDING_THRESHOLD);
+
+		st.update(2 * MAX_SHEDDING_THRESHOLD, 1000, 1000);
+		assertTrue(st.get() <= MAX_SHEDDING_THRESHOLD);
+		
+	}
+
+}


### PR DESCRIPTION
This PR ports tests from [gci-go shedding threshold](https://github.com/gcinterceptor/gci-go/blob/master/gccontrol/shedding_threshold_test.go) and implements tests for Heap and Sampler classes.