### PR TITLE
Update the elasticsearch version required for the current one.

### DIFF
--- a/elasticsearch-plugin/pom.xml
+++ b/elasticsearch-plugin/pom.xml
@@ -12,7 +12,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <elasticsearch.version>6.3.2</elasticsearch.version>
+    <elasticsearch.version>6.4.0</elasticsearch.version>
     <maven.compiler.source>10</maven.compiler.source>
     <maven.compiler.target>10</maven.compiler.target>
   </properties>

--- a/elasticsearch-plugin/src/main/resources/plugin-descriptor.properties
+++ b/elasticsearch-plugin/src/main/resources/plugin-descriptor.properties
@@ -35,7 +35,7 @@ classname=com.gcinterceptor.elasticsearch.GciElasticsearchPlugin
 java.version=10
 #
 # 'elasticsearch.version': version of elasticsearch compiled against
-elasticsearch.version=6.3.2
+elasticsearch.version=6.4.0
 ### optional elements for plugins:
 #
 #  'extended.plugins': other plugins this plugin extends through SPI


### PR DESCRIPTION
The current version of elasticsearch is 6.4.0, not 6.3.2. This PR update the plugin elasticsearch required version. 